### PR TITLE
update cli version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "countdown.js",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "super-simple command line egg-timer",
   "directories": {
       "bin": "./bin"
@@ -25,7 +25,7 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "cli": "^0.4.5",
+    "cli": "^0.11.1",
     "timer.js": "^0.2.0",
     "timestring": "^1.0.1"
   },


### PR DESCRIPTION
v0.4.5 outputs a deprecation notice:

```
countdown.js 1m
INFO: Countdown ends at 1:02:16 PM
(node) util.print is deprecated. Use console.log instead.
[##########################################################################] 100%
INFO: Countdown has ended.
```
